### PR TITLE
pulls information out of select artifacts tables

### DIFF
--- a/app/controllers/admin/bone_inventories_controller.rb
+++ b/app/controllers/admin/bone_inventories_controller.rb
@@ -1,7 +1,7 @@
 class Admin::BoneInventoriesController < ApplicationController
 
   active_scaffold :bone_inventory do |conf|
-    conf.columns = [:site, :units, :strata, :features, :fs_no, :box, :count, :grid_ew, :grid_ns, :quad, :exact_prov, :depth_begin, :depth_end, :strat_alpha, :strat_one, :strat_two, :strat_other, :field_date, :excavator, :art_type, :sa_no, :record_field_key_no, :comments, :entered_by, :location]
+    conf.columns = [:site, :units, :strata, :features, :fs_no, :box, :count, :grid_ew, :grid_ns, :quad, :exact_prov, :depth_begin, :depth_end, :strat_alpha, :strat_one, :strat_two, :strat_other, :field_date, :excavator, :art_type, :sa_no, :record_field_key_no, :comments, :entered_by, :location, :select_artifact_info]
     conf.update.columns = [:site, :fs_no, :box, :count, :grid_ew, :grid_ns, :quad, :exact_prov, :depth_begin, :depth_end, :strat_alpha, :strat_one, :strat_two, :strat_other, :field_date, :excavator, :art_type, :sa_no, :record_field_key_no, :comments, :entered_by, :location]
     conf.columns[:units].form_ui = :record_select
     conf.columns[:strata].form_ui = :record_select

--- a/app/controllers/admin/ceramic_inventories_controller.rb
+++ b/app/controllers/admin/ceramic_inventories_controller.rb
@@ -1,7 +1,7 @@
 class Admin::CeramicInventoriesController < ApplicationController
 
   active_scaffold :ceramic_inventory do |conf|
-    conf.columns = [:site, :units, :strata, :features, :fs_no, :box, :count, :grid_ew, :grid_ns, :quad, :exact_prov, :depth_begin, :depth_end, :strat_alpha, :strat_one, :strat_two, :strat_other, :field_date, :excavator, :art_type, :sa_no, :record_field_key_no, :comments, :entered_by, :location]
+    conf.columns = [:site, :units, :strata, :features, :fs_no, :box, :count, :grid_ew, :grid_ns, :quad, :exact_prov, :depth_begin, :depth_end, :strat_alpha, :strat_one, :strat_two, :strat_other, :field_date, :excavator, :art_type, :sa_no, :record_field_key_no, :comments, :entered_by, :location, :select_artifact_info]
     conf.update.columns = [:site, :fs_no, :box, :count, :grid_ew, :grid_ns, :quad, :exact_prov, :depth_begin, :depth_end, :strat_alpha, :strat_one, :strat_two, :strat_other, :field_date, :excavator, :art_type, :sa_no, :record_field_key_no, :comments, :entered_by, :location]
     # conf.columns[:art_type].form_ui = :select
     conf.columns[:units].form_ui = :record_select

--- a/app/controllers/admin/ceramic_vessels_controller.rb
+++ b/app/controllers/admin/ceramic_vessels_controller.rb
@@ -20,7 +20,8 @@ class Admin::CeramicVesselsController < ApplicationController
       :vessel_percentage,
       :lori_reed_analysis,
       :comments_lori_reed,
-      :comments_other
+      :comments_other,
+      :select_artifact_info
     ]
     ceramic_tables.each do |t|
       conf.columns << t

--- a/app/controllers/admin/lithic_inventories_controller.rb
+++ b/app/controllers/admin/lithic_inventories_controller.rb
@@ -1,7 +1,7 @@
 class Admin::LithicInventoriesController < ApplicationController
 
   active_scaffold :lithic_inventory do |conf|
-    conf.columns = [:site, :units, :strata, :features, :fs_no, :box, :count, :grid_ew, :grid_ns, :quad, :exact_prov, :depth_begin, :depth_end, :strat_alpha, :strat_one, :strat_two, :strat_other, :field_date, :excavator, :art_type, :sa_no, :record_field_key_no, :comments, :entered_by, :location]
+    conf.columns = [:site, :units, :strata, :features, :fs_no, :box, :count, :grid_ew, :grid_ns, :quad, :exact_prov, :depth_begin, :depth_end, :strat_alpha, :strat_one, :strat_two, :strat_other, :field_date, :excavator, :art_type, :sa_no, :record_field_key_no, :comments, :entered_by, :location, :select_artifact_info]
     conf.update.columns = [:site, :fs_no, :box, :count, :grid_ew, :grid_ns, :quad, :exact_prov, :depth_begin, :depth_end, :strat_alpha, :strat_one, :strat_two, :strat_other, :field_date, :excavator, :art_type, :sa_no, :record_field_key_no, :comments, :entered_by, :location]
     # conf.columns[:art_type].form_ui = :select
     conf.columns[:units].form_ui = :record_select

--- a/app/controllers/admin/ornaments_controller.rb
+++ b/app/controllers/admin/ornaments_controller.rb
@@ -1,7 +1,7 @@
 class Admin::OrnamentsController < ApplicationController
 
   active_scaffold :ornament do |conf|
-    conf.columns = [:units, :strata, :feature, :salmon_museum_no, :analysis_lab_no, :grid, :quad, :depth, :field_date, :occupation, :analyst, :analyzed, :photographer, :count, :item]
+    conf.columns = [:units, :strata, :feature, :strat_other, :salmon_museum_no, :sa_no, :analysis_lab_no, :grid, :quad, :depth, :field_date, :occupation, :analyst, :analyzed, :photographer, :count, :item, :select_artifact_info]
     conf.columns[:occupation].form_ui = :select
     conf.columns[:units].form_ui = :record_select
     conf.columns[:strata].form_ui = :record_select

--- a/app/controllers/admin/perishables_controller.rb
+++ b/app/controllers/admin/perishables_controller.rb
@@ -1,7 +1,7 @@
 class Admin::PerishablesController < ApplicationController
 
   active_scaffold :perishable do |conf|
-    conf.columns = [:units, :strata, :features, :fs_no, :salmon_museum_number, :grid, :quad, :depth, :occupation, :sa_no, :artifact_type, :count, :artifact_structure, :comments, :comments_other, :storage_location, :exhibit_location, :record_field_key_no, :museum_lab_no, :field_date, :original_analysis]
+    conf.columns = [:units, :strata, :features, :fs_no, :salmon_museum_number, :grid, :quad, :depth, :occupation, :sa_no, :artifact_type, :count, :artifact_structure, :comments, :comments_other, :storage_location, :exhibit_location, :record_field_key_no, :museum_lab_no, :field_date, :original_analysis, :select_artifact_info]
     conf.columns[:occupation].form_ui = :select
     conf.columns[:units].form_ui = :record_select
     conf.columns[:strata].form_ui = :record_select

--- a/app/controllers/admin/select_artifacts_controller.rb
+++ b/app/controllers/admin/select_artifacts_controller.rb
@@ -1,10 +1,11 @@
 class Admin::SelectArtifactsController < ApplicationController
 
   active_scaffold :select_artifact do |conf|
-    conf.columns = [:units, :strata, :artifact_no, :floor_association, :sa_form, :associated_feature_artifacts, :grid, :depth, :occupation, :select_artifact_type, :artifact_count, :location_in_room, :comments]
+    conf.columns = [:units, :strata, :features, :sa_no, :appears_in_table, :floor_association, :sa_form, :associated_feature_artifacts, :grid, :depth, :occupation, :select_artifact_type, :artifact_count, :location_in_room, :comments]
     conf.columns[:occupation].form_ui = :select
     conf.columns[:units].form_ui = :record_select
     conf.columns[:strata].form_ui = :record_select
+    conf.columns[:features].form_ui = :record_select
     conf.actions.swap :search, :field_search
   end
 

--- a/app/controllers/admin/wood_inventories_controller.rb
+++ b/app/controllers/admin/wood_inventories_controller.rb
@@ -19,7 +19,8 @@ class Admin::WoodInventoriesController < ApplicationController
       :field_date,
       :lab,
       :analysis,
-      :description
+      :description,
+      :select_artifact_info
     ]
     conf.columns[:strata].form_ui = :record_select
     conf.columns[:features].form_ui = :record_select

--- a/app/models/feature.rb
+++ b/app/models/feature.rb
@@ -22,6 +22,7 @@ class Feature < ActiveRecord::Base
   has_and_belongs_to_many :lithic_inventories
   has_and_belongs_to_many :perishables
   has_and_belongs_to_many :pollen_inventories
+  has_and_belongs_to_many :select_artifacts
   has_and_belongs_to_many :soils
   has_and_belongs_to_many :wood_inventories
 

--- a/app/models/select_artifact.rb
+++ b/app/models/select_artifact.rb
@@ -1,6 +1,7 @@
 class SelectArtifact < ApplicationRecord
   belongs_to :occupation
-  has_and_belongs_to_many :strata
+  has_and_belongs_to_many :features
+  has_many :strata, -> {distinct}, :through => :features
   has_many :units, -> {distinct}, :through => :strata
 
   def self.sorted

--- a/app/models/stratum.rb
+++ b/app/models/stratum.rb
@@ -7,7 +7,6 @@ class Stratum < ActiveRecord::Base
   has_many :tree_rings
   has_and_belongs_to_many :bone_tools
   has_and_belongs_to_many :features
-  has_and_belongs_to_many :select_artifacts
 
   def to_label
     "#{unit.to_label if unit} : #{strat_all} #{strat_alpha}"

--- a/db/migrate/20170623180012_split_select_artifacts.rb
+++ b/db/migrate/20170623180012_split_select_artifacts.rb
@@ -1,0 +1,38 @@
+class SplitSelectArtifacts < ActiveRecord::Migration[5.0]
+  def change
+
+    # SELECT ARTIFACTS
+
+    # associate with features, not strata
+    drop_join_table :select_artifacts, :strata
+
+    create_join_table :select_artifacts, :features do |t|
+      t.references :select_artifact, index: true, foreign_key: true
+      t.references :feature, index: true, foreign_key: true
+    end
+
+    # match naming convention used elsewhere
+    rename_column :select_artifacts, :artifact_no, :sa_no
+
+    add_column :select_artifacts, :feature_no, :string
+    # I decided against trying to join SA to each table in some way
+    # because some of them have multiple SA #, etc
+    # so just noting which table it was added to in case lookup needed later
+    add_column :select_artifacts, :appears_in_table, :string
+    add_column :select_artifacts, :strat_other, :string
+
+    # OTHER TABLES
+
+    # ornaments was not previously storing the sa_no
+    add_column :ornaments, :sa_no, :string
+    add_column :ornaments, :strat_other, :string
+
+    add_column :bone_inventories, :select_artifact_info, :string
+    add_column :ceramic_inventories, :select_artifact_info, :string
+    add_column :lithic_inventories, :select_artifact_info, :string
+    add_column :ornaments, :select_artifact_info, :string
+    add_column :perishables, :select_artifact_info, :string
+    add_column :ceramic_vessels, :select_artifact_info, :string
+    add_column :wood_inventories, :select_artifact_info, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170619192052) do
+ActiveRecord::Schema.define(version: 20170623180012) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -46,8 +46,9 @@ ActiveRecord::Schema.define(version: 20170619192052) do
     t.text     "comments"
     t.string   "entered_by"
     t.string   "location"
-    t.datetime "created_at",          null: false
-    t.datetime "updated_at",          null: false
+    t.datetime "created_at",           null: false
+    t.datetime "updated_at",           null: false
+    t.string   "select_artifact_info"
   end
 
   create_table "bone_inventories_features", id: false, force: :cascade do |t|
@@ -225,8 +226,9 @@ ActiveRecord::Schema.define(version: 20170619192052) do
     t.text     "comments"
     t.string   "entered_by"
     t.string   "location"
-    t.datetime "created_at",          null: false
-    t.datetime "updated_at",          null: false
+    t.datetime "created_at",           null: false
+    t.datetime "updated_at",           null: false
+    t.string   "select_artifact_info"
   end
 
   create_table "ceramic_inventories_features", id: false, force: :cascade do |t|
@@ -334,6 +336,7 @@ ActiveRecord::Schema.define(version: 20170619192052) do
     t.integer "ceramic_vessel_type_id"
     t.integer "ceramic_vessel_lori_reed_type_id"
     t.integer "ceramic_inventory_id"
+    t.string  "select_artifact_info"
     t.index ["ceramic_inventory_id"], name: "index_ceramic_vessels_on_ceramic_inventory_id", using: :btree
     t.index ["ceramic_vessel_lori_reed_form_id"], name: "index_ceramic_vessels_on_ceramic_vessel_lori_reed_form_id", using: :btree
     t.index ["ceramic_vessel_lori_reed_type_id"], name: "index_ceramic_vessels_on_ceramic_vessel_lori_reed_type_id", using: :btree
@@ -630,6 +633,13 @@ ActiveRecord::Schema.define(version: 20170619192052) do
     t.index ["pollen_inventory_id"], name: "index_features_pollen_inventories_on_pollen_inventory_id", using: :btree
   end
 
+  create_table "features_select_artifacts", id: false, force: :cascade do |t|
+    t.integer "select_artifact_id"
+    t.integer "feature_id"
+    t.index ["feature_id"], name: "index_features_select_artifacts_on_feature_id", using: :btree
+    t.index ["select_artifact_id"], name: "index_features_select_artifacts_on_select_artifact_id", using: :btree
+  end
+
   create_table "features_soils", id: false, force: :cascade do |t|
     t.integer "soil_id"
     t.integer "feature_id"
@@ -834,8 +844,9 @@ ActiveRecord::Schema.define(version: 20170619192052) do
     t.text     "comments"
     t.string   "entered_by"
     t.string   "location"
-    t.datetime "created_at",          null: false
-    t.datetime "updated_at",          null: false
+    t.datetime "created_at",           null: false
+    t.datetime "updated_at",           null: false
+    t.string   "select_artifact_info"
   end
 
   create_table "lithic_material_types", force: :cascade do |t|
@@ -951,9 +962,12 @@ ActiveRecord::Schema.define(version: 20170619192052) do
     t.string   "photographer"
     t.integer  "count"
     t.string   "item"
-    t.datetime "created_at",       null: false
-    t.datetime "updated_at",       null: false
+    t.datetime "created_at",           null: false
+    t.datetime "updated_at",           null: false
     t.integer  "occupation_id"
+    t.string   "sa_no"
+    t.string   "strat_other"
+    t.string   "select_artifact_info"
     t.index ["occupation_id"], name: "index_ornaments_on_occupation_id", using: :btree
   end
 
@@ -981,6 +995,7 @@ ActiveRecord::Schema.define(version: 20170619192052) do
     t.datetime "created_at",           null: false
     t.datetime "updated_at",           null: false
     t.integer  "occupation_id"
+    t.string   "select_artifact_info"
     t.index ["occupation_id"], name: "index_perishables_on_occupation_id", using: :btree
   end
 
@@ -1026,7 +1041,7 @@ ActiveRecord::Schema.define(version: 20170619192052) do
 
   create_table "select_artifacts", force: :cascade do |t|
     t.string   "unit"
-    t.string   "artifact_no"
+    t.string   "sa_no"
     t.string   "strat"
     t.string   "floor_association"
     t.string   "sa_form"
@@ -1040,14 +1055,10 @@ ActiveRecord::Schema.define(version: 20170619192052) do
     t.datetime "created_at",                   null: false
     t.datetime "updated_at",                   null: false
     t.integer  "occupation_id"
+    t.string   "feature_no"
+    t.string   "appears_in_table"
+    t.string   "strat_other"
     t.index ["occupation_id"], name: "index_select_artifacts_on_occupation_id", using: :btree
-  end
-
-  create_table "select_artifacts_strata", id: false, force: :cascade do |t|
-    t.integer "select_artifact_id"
-    t.integer "stratum_id"
-    t.index ["select_artifact_id"], name: "index_select_artifacts_strata_on_select_artifact_id", using: :btree
-    t.index ["stratum_id"], name: "index_select_artifacts_strata_on_stratum_id", using: :btree
   end
 
   create_table "soils", force: :cascade do |t|
@@ -1226,6 +1237,7 @@ ActiveRecord::Schema.define(version: 20170619192052) do
     t.string "lab"
     t.string "analysis"
     t.string "description"
+    t.string "select_artifact_info"
   end
 
   create_table "zones", force: :cascade do |t|
@@ -1266,6 +1278,8 @@ ActiveRecord::Schema.define(version: 20170619192052) do
   add_foreign_key "features_perishables", "perishables"
   add_foreign_key "features_pollen_inventories", "features"
   add_foreign_key "features_pollen_inventories", "pollen_inventories"
+  add_foreign_key "features_select_artifacts", "features"
+  add_foreign_key "features_select_artifacts", "select_artifacts"
   add_foreign_key "features_soils", "features"
   add_foreign_key "features_soils", "soils"
   add_foreign_key "features_strata", "features"
@@ -1283,8 +1297,6 @@ ActiveRecord::Schema.define(version: 20170619192052) do
   add_foreign_key "images", "image_qualities"
   add_foreign_key "lithic_inventories", "features"
   add_foreign_key "ornaments", "features"
-  add_foreign_key "select_artifacts_strata", "select_artifacts"
-  add_foreign_key "select_artifacts_strata", "strata"
   add_foreign_key "soils", "art_types"
   add_foreign_key "strata", "strat_types"
   add_foreign_key "strata", "units"

--- a/reports/please_check_for_accuracy.txt
+++ b/reports/please_check_for_accuracy.txt
@@ -1,5 +1,25 @@
 Please review the following and verify that units, strata, etc, were added correctly
 
+Unit 049W created from Stratum A-1-1
+Unit 110W created from Stratum B-1-2
+Unit 111W created from Stratum B-1-2
+Unit 112W created from Stratum B-1-2
+stratum 031W:B-1-2 created from Feature 1.0
+stratum 033W:L-1-5.5 created from Feature 6.0
+stratum 036W:B-2-3 created from Feature 1.0
+stratum 036W:n/a created from Feature 8.0
+stratum 062A:I-1-6 created from Feature 12.0
+stratum 062W:I-1-4.2 created from Feature 3.0
+stratum 089W:H-1-12 created from Feature 1.0
+stratum 092W:B-4-5 created from Feature 5.0
+stratum 093W:L-0.5.-8.5 created from Feature 12.0
+stratum 099W:H-1-9 created from Feature 26.0
+stratum 119W:L-3-15 created from Feature 24.0
+stratum 119W:I-11.6-39.6 created from Feature 116.0
+stratum 121E:D-2-4 created from Feature 48.0
+stratum 127W:D-3-11 created from Feature 97.0
+[blank] Doorway Sealed created from Features row 1701
+stratum 129W:C-70-78 created from Feature 77.0
 [blank] Box created from Ceramic Inventories row 145
 [blank] Box created from Ceramic Inventories row 146
 [blank] Box created from Ceramic Inventories row 171
@@ -3083,14 +3103,749 @@ stratum 121W:L-16-13 created from Perishables
 feature 121W:L-16-13:33.0 created from Perishables
 stratum 127W:L-23.44 created from Perishables
 feature 127W:L-23.44:147.0 created from Perishables
-stratum 018P:L-1-08 created from SA SA018P002
-stratum 018P:Q-1-07 created from SA SA018P008
-stratum 057W:L-2-9 created from SA SA057W023
+Perishable new record with sa_no SA007A003 created from Select Artifacts
+WoodInventory new record with sa_no SA008BW003 created from Select Artifacts
+Perishable new record with sa_no SA017P002 created from Select Artifacts
+stratum 018P:L-1-08 created from Select Artifacts
+feature 018P:L-1-08:1.0 created from Select Artifacts
+LithicInventory new record with sa_no SA018P002 created from Select Artifacts
+LithicInventory new record with sa_no SA018P003 created from Select Artifacts
+CeramicInventory new record with sa_no SA018P004 created from Select Artifacts
+Perishable new record with sa_no SA018P005 created from Select Artifacts
+stratum 018P:Q-1-07 created from Select Artifacts
+feature 018P:Q-1-07:7.0 created from Select Artifacts
+LithicInventory new record with sa_no SA018P009 created from Select Artifacts
+LithicInventory new record with sa_no SA018P010 created from Select Artifacts
+LithicInventory new record with sa_no SA018P014 created from Select Artifacts
+LithicInventory new record with sa_no SA018P016 created from Select Artifacts
+CeramicVessel new record with sa_no SA019P003 created from Select Artifacts
+feature 019P:L-1-12:5.0 created from Select Artifacts
+LithicInventory new record with sa_no SA019P008 created from Select Artifacts
+CeramicVessel new record with sa_no SA020P020 created from Select Artifacts
+CeramicVessel new record with sa_no SA020P021 created from Select Artifacts
+feature 021P:R-3-19.7:27.0 created from Select Artifacts
+LithicInventory new record with sa_no SA021P026 created from Select Artifacts
+feature 030B:G-1-4:7.0 created from Select Artifacts
+Perishable new record with sa_no SA030B006 created from Select Artifacts
+LithicInventory new record with sa_no SA031A003 created from Select Artifacts
+LithicInventory new record with sa_no SA031B001 created from Select Artifacts
+Perishable new record with sa_no SA031W012 created from Select Artifacts
+CeramicVessel new record with sa_no SA031W016 created from Select Artifacts
+Perishable new record with sa_no SA033B001 created from Select Artifacts
+feature 033B:L-1-3:2.0 created from Select Artifacts
+Perishable new record with sa_no SA033B005 created from Select Artifacts
+LithicInventory new record with sa_no SA033B008 created from Select Artifacts
+CeramicVessel new record with sa_no SA033W001 created from Select Artifacts
+feature 033W:F-2-9:12.0 created from Select Artifacts
+LithicInventory new record with sa_no SA033W006 created from Select Artifacts
+CeramicVessel new record with sa_no SA033W007 created from Select Artifacts
+CeramicVessel new record with sa_no SA033W008 created from Select Artifacts
+CeramicVessel new record with sa_no SA033W009 created from Select Artifacts
+Perishable new record with sa_no SA033W010 created from Select Artifacts
+CeramicVessel new record with sa_no SA033W013 created from Select Artifacts
+LithicInventory new record with sa_no SA033W014 created from Select Artifacts
+BoneInventory new record with sa_no SA033W016 created from Select Artifacts
+Perishable new record with sa_no SA033W017 created from Select Artifacts
+Perishable new record with sa_no SA033W018 created from Select Artifacts
+LithicInventory new record with sa_no SA033W020 created from Select Artifacts
+LithicInventory new record with sa_no SA033W024 created from Select Artifacts
+LithicInventory new record with sa_no SA033W044 created from Select Artifacts
+Perishable new record with sa_no SA033W046 created from Select Artifacts
+LithicInventory new record with sa_no SA033W048 created from Select Artifacts
+BoneInventory new record with sa_no SA033W050 created from Select Artifacts
+Perishable new record with sa_no SA036W005 created from Select Artifacts
+CeramicVessel new record with sa_no SA036W009 created from Select Artifacts
+LithicInventory new record with sa_no SA036W011 created from Select Artifacts
+CeramicInventory new record with sa_no SA036W013 created from Select Artifacts
+BoneInventory new record with sa_no SA036W014 created from Select Artifacts
+LithicInventory new record with sa_no SA036W015 created from Select Artifacts
+Ornament new record with sa_no SA036W016 created from Select Artifacts
+Ornament new record with sa_no SA036W027 created from Select Artifacts
+CeramicVessel new record with sa_no SA036W042 created from Select Artifacts
+LithicInventory new record with sa_no SA036W043 created from Select Artifacts
+LithicInventory new record with sa_no SA036W047 created from Select Artifacts
+LithicInventory new record with sa_no SA036W052 created from Select Artifacts
+LithicInventory new record with sa_no SA036W054 created from Select Artifacts
+LithicInventory new record with sa_no SA036W055 created from Select Artifacts
+LithicInventory new record with sa_no SA036W057 created from Select Artifacts
+LithicInventory new record with sa_no SA036W060 created from Select Artifacts
+LithicInventory new record with sa_no SA036W063 created from Select Artifacts
+LithicInventory new record with sa_no SA037W069 created from Select Artifacts
+CeramicVessel new record with sa_no SA037W070 created from Select Artifacts
+CeramicVessel new record with sa_no SA037W071 created from Select Artifacts
+CeramicVessel new record with sa_no SA037W072 created from Select Artifacts
+CeramicVessel new record with sa_no SA037W073 created from Select Artifacts
+LithicInventory new record with sa_no SA037W074 created from Select Artifacts
+CeramicVessel new record with sa_no SA037W078 created from Select Artifacts
+LithicInventory new record with sa_no SA037W080 created from Select Artifacts
+CeramicVessel new record with sa_no SA037W091 created from Select Artifacts
+CeramicVessel new record with sa_no SA037W092 created from Select Artifacts
+CeramicVessel new record with sa_no SA037W093 created from Select Artifacts
+CeramicVessel new record with sa_no SA037W094 created from Select Artifacts
+CeramicVessel new record with sa_no SA037W095 created from Select Artifacts
+CeramicVessel new record with sa_no SA037W096 created from Select Artifacts
+CeramicVessel new record with sa_no SA037W097 created from Select Artifacts
+CeramicVessel new record with sa_no SA037W098 created from Select Artifacts
+CeramicVessel new record with sa_no SA037W099 created from Select Artifacts
+CeramicVessel new record with sa_no SA037W100 created from Select Artifacts
+CeramicVessel new record with sa_no SA037W101 created from Select Artifacts
+CeramicVessel new record with sa_no SA037W102 created from Select Artifacts
+CeramicVessel new record with sa_no SA037W103 created from Select Artifacts
+CeramicVessel new record with sa_no SA037W104 created from Select Artifacts
+Perishable new record with sa_no SA037W105 created from Select Artifacts
+BoneInventory new record with sa_no SA043W014 created from Select Artifacts
+Perishable new record with sa_no SA043W015 created from Select Artifacts
+Perishable new record with sa_no SA043W016 created from Select Artifacts
+LithicInventory new record with sa_no SA043W023 created from Select Artifacts
+CeramicVessel new record with sa_no SA043W029 created from Select Artifacts
+feature 043W:L-2-7.5:19.0 created from Select Artifacts
+Ornament new record with sa_no SA043W033 created from Select Artifacts
+LithicInventory new record with sa_no SA043W034 created from Select Artifacts
+Perishable new record with sa_no SA043W035 created from Select Artifacts
+BoneInventory new record with sa_no SA043W037 created from Select Artifacts
+WoodInventory new record with sa_no SA043W038 created from Select Artifacts
+Perishable new record with sa_no SA043W051 created from Select Artifacts
+CeramicVessel new record with sa_no SA043W061 created from Select Artifacts
+CeramicVessel new record with sa_no SA043W062 created from Select Artifacts
+CeramicVessel new record with sa_no SA043W063 created from Select Artifacts
+CeramicVessel new record with sa_no SA043W064 created from Select Artifacts
+CeramicVessel new record with sa_no SA043W065 created from Select Artifacts
+WoodInventory new record with sa_no SA043W067 created from Select Artifacts
+LithicInventory new record with sa_no SA051W001 created from Select Artifacts
+LithicInventory new record with sa_no SA051W003 created from Select Artifacts
+LithicInventory new record with sa_no SA051W004 created from Select Artifacts
+WoodInventory new record with sa_no SA051W005 created from Select Artifacts
+LithicInventory new record with sa_no SA051W007 created from Select Artifacts
+LithicInventory new record with sa_no SA051W008.1 created from Select Artifacts
+LithicInventory new record with sa_no SA051W008.2 created from Select Artifacts
+Ornament new record with sa_no SA057W022 created from Select Artifacts
+stratum 057W:L-2-9 created from Select Artifacts
+feature 057W:L-2-9:24.0 created from Select Artifacts
+LithicInventory new record with sa_no SA057W023 created from Select Artifacts
+feature 058W:N-1-5:12.0 created from Select Artifacts
+LithicInventory new record with sa_no SA058W013 created from Select Artifacts
+CeramicVessel new record with sa_no SA058W014 created from Select Artifacts
+CeramicVessel new record with sa_no SA058W015 created from Select Artifacts
+LithicInventory new record with sa_no SA058W017 created from Select Artifacts
+CeramicVessel new record with sa_no SA059W009 created from Select Artifacts
+CeramicVessel new record with sa_no SA059W011 created from Select Artifacts
+WoodInventory new record with sa_no SA060A013 created from Select Artifacts
+Perishable new record with sa_no SA062A001 created from Select Artifacts
+WoodInventory new record with sa_no SA062A002 created from Select Artifacts
+CeramicInventory new record with sa_no SA062A008 created from Select Artifacts
+LithicInventory new record with sa_no SA062A024 created from Select Artifacts
+CeramicVessel new record with sa_no SA062A026 created from Select Artifacts
+LithicInventory new record with sa_no SA062A028 created from Select Artifacts
+CeramicVessel new record with sa_no SA062A032 created from Select Artifacts
+LithicInventory new record with sa_no SA062A033 created from Select Artifacts
+CeramicVessel new record with sa_no SA062A034 created from Select Artifacts
+BoneInventory new record with sa_no SA062A035 created from Select Artifacts
+LithicInventory new record with sa_no SA062A036 created from Select Artifacts
+CeramicVessel new record with sa_no SA062A037 created from Select Artifacts
+LithicInventory new record with sa_no SA062A039 created from Select Artifacts
+LithicInventory new record with sa_no SA062A040 created from Select Artifacts
+Perishable new record with sa_no SA062A042 created from Select Artifacts
+CeramicVessel new record with sa_no SA062A044 created from Select Artifacts
+CeramicVessel new record with sa_no SA062A045 created from Select Artifacts
+CeramicVessel new record with sa_no SA062A046 created from Select Artifacts
+BoneInventory new record with sa_no SA062A047 created from Select Artifacts
+WoodInventory new record with sa_no SA062A048 created from Select Artifacts
+CeramicVessel new record with sa_no SA062A049 created from Select Artifacts
+CeramicVessel new record with sa_no SA062A050 created from Select Artifacts
+CeramicVessel new record with sa_no SA062A051 created from Select Artifacts
+LithicInventory new record with sa_no SA062A052 created from Select Artifacts
+LithicInventory new record with sa_no SA062A055 created from Select Artifacts
+LithicInventory new record with sa_no SA062A056 created from Select Artifacts
+LithicInventory new record with sa_no SA062A057 created from Select Artifacts
+LithicInventory new record with sa_no SA062A058 created from Select Artifacts
+LithicInventory new record with sa_no SA062A059 created from Select Artifacts
+LithicInventory new record with sa_no SA062A061 created from Select Artifacts
+LithicInventory new record with sa_no SA062A066 created from Select Artifacts
+LithicInventory new record with sa_no SA062A067 created from Select Artifacts
+LithicInventory new record with sa_no SA062A068 created from Select Artifacts
+LithicInventory new record with sa_no SA062A069 created from Select Artifacts
+LithicInventory new record with sa_no SA062A070 created from Select Artifacts
+LithicInventory new record with sa_no SA062A071 created from Select Artifacts
+LithicInventory new record with sa_no SA062A072 created from Select Artifacts
+LithicInventory new record with sa_no SA062A073 created from Select Artifacts
+LithicInventory new record with sa_no SA062A075 created from Select Artifacts
+LithicInventory new record with sa_no SA062A076 created from Select Artifacts
+LithicInventory new record with sa_no SA062A088 created from Select Artifacts
+feature 062A:I-2-6:90.0 created from Select Artifacts
+LithicInventory new record with sa_no SA062W074 created from Select Artifacts
+LithicInventory new record with sa_no SA062W077 created from Select Artifacts
+LithicInventory new record with sa_no SA062W078 created from Select Artifacts
+LithicInventory new record with sa_no SA062W080 created from Select Artifacts
+LithicInventory new record with sa_no SA062W081 created from Select Artifacts
+LithicInventory new record with sa_no SA062W124 created from Select Artifacts
+CeramicVessel new record with sa_no SA064W032 created from Select Artifacts
+CeramicVessel new record with sa_no SA064W034 created from Select Artifacts
+Ornament new record with sa_no SA064W036 created from Select Artifacts
+CeramicVessel new record with sa_no SA064W037 created from Select Artifacts
+CeramicVessel new record with sa_no SA064W038 created from Select Artifacts
+CeramicVessel new record with sa_no SA064W039 created from Select Artifacts
+CeramicVessel new record with sa_no SA064W040 created from Select Artifacts
+LithicInventory new record with sa_no SA064W043 created from Select Artifacts
+feature 064W:L-2-10:53.0 created from Select Artifacts
+BoneInventory new record with sa_no SA064W052 created from Select Artifacts
+BoneInventory new record with sa_no SA064W053 created from Select Artifacts
+LithicInventory new record with sa_no SA064W055 created from Select Artifacts
+BoneInventory new record with sa_no SA064W058 created from Select Artifacts
+BoneInventory new record with sa_no SA064W060 created from Select Artifacts
+WoodInventory new record with sa_no SA064W065 created from Select Artifacts
+LithicInventory new record with sa_no SA064W081 created from Select Artifacts
+CeramicVessel new record with sa_no SA064W088 created from Select Artifacts
+CeramicVessel new record with sa_no SA064W092 created from Select Artifacts
+LithicInventory new record with sa_no SA064W093 created from Select Artifacts
+feature 064W:H-1-8:7.0 created from Select Artifacts
+LithicInventory new record with sa_no SA064W094 created from Select Artifacts
+feature 064W:H-1-8:47.0 created from Select Artifacts
+LithicInventory new record with sa_no SA064W095 created from Select Artifacts
+Perishable new record with sa_no SA064W098 created from Select Artifacts
+CeramicVessel new record with sa_no SA064W099 created from Select Artifacts
+LithicInventory new record with sa_no SA064W100 created from Select Artifacts
+WoodInventory new record with sa_no SA064W101 created from Select Artifacts
+CeramicVessel new record with sa_no SA064W102 created from Select Artifacts
+CeramicVessel new record with sa_no SA064W103 created from Select Artifacts
+CeramicVessel new record with sa_no SA064W104 created from Select Artifacts
+CeramicVessel new record with sa_no SA064W105 created from Select Artifacts
+CeramicVessel new record with sa_no SA064W106 created from Select Artifacts
+CeramicVessel new record with sa_no SA064W107 created from Select Artifacts
+CeramicVessel new record with sa_no SA064W108 created from Select Artifacts
+CeramicVessel new record with sa_no SA064W109 created from Select Artifacts
+BoneInventory new record with sa_no SA064W110 created from Select Artifacts
+CeramicVessel new record with sa_no SA064W111 created from Select Artifacts
+CeramicVessel new record with sa_no SA064W112 created from Select Artifacts
+Ornament new record with sa_no SA064W119 created from Select Artifacts
+LithicInventory new record with sa_no SA064W122 created from Select Artifacts
+LithicInventory new record with sa_no SA064W126 created from Select Artifacts
+CeramicVessel new record with sa_no SA064W128 created from Select Artifacts
+CeramicVessel new record with sa_no SA064W129 created from Select Artifacts
+LithicInventory new record with sa_no SA064W130 created from Select Artifacts
+LithicInventory new record with sa_no SA064W131 created from Select Artifacts
+LithicInventory new record with sa_no SA064W132 created from Select Artifacts
+CeramicVessel new record with sa_no SA064W133 created from Select Artifacts
+LithicInventory new record with sa_no SA064W134 created from Select Artifacts
+LithicInventory new record with sa_no SA064W135 created from Select Artifacts
+WoodInventory new record with sa_no SA064W136 created from Select Artifacts
 [blank] Unit created from Select Artifacts row 337
-stratum [blank]:F-2-6 created from SA SA067W025
-stratum 119W:H-4.5-22.5 created from SA SA119W096
-stratum 119W:W-1-91 created from SA SA119W103
-stratum 121W:H-1-6 created from SA SA121W002
+stratum [blank]:F-2-6 created from Select Artifacts
+WoodInventory new record with sa_no SA067W025 created from Select Artifacts
+WoodInventory new record with sa_no SA067W026 created from Select Artifacts
+BoneInventory new record with sa_no SA081W002 created from Select Artifacts
+BoneInventory new record with sa_no SA081W100 created from Select Artifacts
+BoneInventory new record with sa_no SA081W148 created from Select Artifacts
+BoneInventory new record with sa_no SA081W250 created from Select Artifacts
+WoodInventory new record with sa_no SA081W251 created from Select Artifacts
+CeramicVessel new record with sa_no SA081W252 created from Select Artifacts
+WoodInventory new record with sa_no SA081W253 created from Select Artifacts
+CeramicInventory new record with sa_no SA081W332 created from Select Artifacts
+BoneInventory new record with sa_no SA081W338 created from Select Artifacts
+WoodInventory new record with sa_no SA081W354 created from Select Artifacts
+LithicInventory new record with sa_no SA082A038 created from Select Artifacts
+LithicInventory new record with sa_no SA082A041 created from Select Artifacts
+BoneInventory new record with sa_no SA082A047 created from Select Artifacts
+LithicInventory new record with sa_no SA082A049 created from Select Artifacts
+LithicInventory new record with sa_no SA082A050 created from Select Artifacts
+LithicInventory new record with sa_no SA082A054 created from Select Artifacts
+CeramicInventory new record with sa_no SA082A055 created from Select Artifacts
+LithicInventory new record with sa_no SA082A056 created from Select Artifacts
+LithicInventory new record with sa_no SA082A057 created from Select Artifacts
+LithicInventory new record with sa_no SA082A058 created from Select Artifacts
+LithicInventory new record with sa_no SA082A062 created from Select Artifacts
+LithicInventory new record with sa_no SA082A063 created from Select Artifacts
+LithicInventory new record with sa_no SA082A064 created from Select Artifacts
+LithicInventory new record with sa_no SA082A065 created from Select Artifacts
+LithicInventory new record with sa_no SA082A066 created from Select Artifacts
+LithicInventory new record with sa_no SA082A067 created from Select Artifacts
+CeramicVessel new record with sa_no SA082W016 created from Select Artifacts
+CeramicVessel new record with sa_no SA082W018 created from Select Artifacts
+feature 082W:M-2-13.5:14.0 created from Select Artifacts
+Ornament new record with sa_no SA082W019.1 created from Select Artifacts
+Ornament new record with sa_no SA082W019.2 created from Select Artifacts
+Ornament new record with sa_no SA082W019.3 created from Select Artifacts
+Ornament new record with sa_no SA082W020 created from Select Artifacts
+Ornament new record with sa_no SA082W021 created from Select Artifacts
+WoodInventory new record with sa_no SA082W028.1 created from Select Artifacts
+CeramicVessel new record with sa_no SA082W028.2 created from Select Artifacts
+CeramicVessel new record with sa_no SA082W029 created from Select Artifacts
+Perishable new record with sa_no SA082W032 created from Select Artifacts
+WoodInventory new record with sa_no SA082W033 created from Select Artifacts
+LithicInventory new record with sa_no SA082W060 created from Select Artifacts
+LithicInventory new record with sa_no SA082W061 created from Select Artifacts
+LithicInventory new record with sa_no SA082W087 created from Select Artifacts
+LithicInventory new record with sa_no SA082W091 created from Select Artifacts
+LithicInventory new record with sa_no SA082W092 created from Select Artifacts
+LithicInventory new record with sa_no SA082W095 created from Select Artifacts
+LithicInventory new record with sa_no SA082W096 created from Select Artifacts
+LithicInventory new record with sa_no SA082W097 created from Select Artifacts
+LithicInventory new record with sa_no SA082W098 created from Select Artifacts
+LithicInventory new record with sa_no SA082W099 created from Select Artifacts
+LithicInventory new record with sa_no SA082W100 created from Select Artifacts
+LithicInventory new record with sa_no SA082W101 created from Select Artifacts
+LithicInventory new record with sa_no SA082W102 created from Select Artifacts
+LithicInventory new record with sa_no SA082W105 created from Select Artifacts
+LithicInventory new record with sa_no SA082W110 created from Select Artifacts
+LithicInventory new record with sa_no SA082W111 created from Select Artifacts
+LithicInventory new record with sa_no SA082W112 created from Select Artifacts
+LithicInventory new record with sa_no SA082W113 created from Select Artifacts
+LithicInventory new record with sa_no SA082W115 created from Select Artifacts
+LithicInventory new record with sa_no SA082W118 created from Select Artifacts
+LithicInventory new record with sa_no SA082W120 created from Select Artifacts
+LithicInventory new record with sa_no SA082W126 created from Select Artifacts
+LithicInventory new record with sa_no SA082W128 created from Select Artifacts
+LithicInventory new record with sa_no SA082W129 created from Select Artifacts
+LithicInventory new record with sa_no SA082W131 created from Select Artifacts
+LithicInventory new record with sa_no SA082W134 created from Select Artifacts
+LithicInventory new record with sa_no SA082W200 created from Select Artifacts
+Ornament new record with sa_no SA084W001 created from Select Artifacts
+LithicInventory new record with sa_no SA084W4007 created from Select Artifacts
+Perishable new record with sa_no SA084W4008 created from Select Artifacts
+LithicInventory new record with sa_no SA084W4009 created from Select Artifacts
+LithicInventory new record with sa_no SA084W4010 created from Select Artifacts
+LithicInventory new record with sa_no SA084W4013 created from Select Artifacts
+BoneInventory new record with sa_no SA084W4014 created from Select Artifacts
+LithicInventory new record with sa_no SA086W031 created from Select Artifacts
+BoneInventory new record with sa_no SA086W036 created from Select Artifacts
+CeramicInventory new record with sa_no SA086W046 created from Select Artifacts
+LithicInventory new record with sa_no SA086W064 created from Select Artifacts
+BoneInventory new record with sa_no SA086W076 created from Select Artifacts
+LithicInventory new record with sa_no SA086W112 created from Select Artifacts
+CeramicVessel new record with sa_no SA086W113 created from Select Artifacts
+CeramicVessel new record with sa_no SA086W114 created from Select Artifacts
+CeramicVessel new record with sa_no SA086W116 created from Select Artifacts
+CeramicVessel new record with sa_no SA086W117 created from Select Artifacts
+Perishable new record with sa_no SA086W118 created from Select Artifacts
+CeramicVessel new record with sa_no SA086W123 created from Select Artifacts
+LithicInventory new record with sa_no SA088W003 created from Select Artifacts
+LithicInventory new record with sa_no SA090W020 created from Select Artifacts
+LithicInventory new record with sa_no SA090W021 created from Select Artifacts
+BoneInventory new record with sa_no SA090W022 created from Select Artifacts
+BoneInventory new record with sa_no SA090W023 created from Select Artifacts
+BoneInventory new record with sa_no SA090W024 created from Select Artifacts
+BoneInventory new record with sa_no SA090W025 created from Select Artifacts
+BoneInventory new record with sa_no SA090W026 created from Select Artifacts
+BoneInventory new record with sa_no SA090W027 created from Select Artifacts
+LithicInventory new record with sa_no SA090W028 created from Select Artifacts
+LithicInventory new record with sa_no SA090W029 created from Select Artifacts
+LithicInventory new record with sa_no SA090W030 created from Select Artifacts
+LithicInventory new record with sa_no SA090W031 created from Select Artifacts
+LithicInventory new record with sa_no SA090W032 created from Select Artifacts
+LithicInventory new record with sa_no SA090W033 created from Select Artifacts
+LithicInventory new record with sa_no SA090W034 created from Select Artifacts
+LithicInventory new record with sa_no SA090W035 created from Select Artifacts
+LithicInventory new record with sa_no SA090W036 created from Select Artifacts
+LithicInventory new record with sa_no SA090W037 created from Select Artifacts
+LithicInventory new record with sa_no SA090W047 created from Select Artifacts
+LithicInventory new record with sa_no SA090W121 created from Select Artifacts
+CeramicVessel new record with sa_no SA091A005 created from Select Artifacts
+LithicInventory new record with sa_no SA091A006 created from Select Artifacts
+CeramicVessel new record with sa_no SA091A007 created from Select Artifacts
+LithicInventory new record with sa_no SA091A008 created from Select Artifacts
+LithicInventory new record with sa_no SA091C015 created from Select Artifacts
+CeramicInventory new record with sa_no SA091C019 created from Select Artifacts
+LithicInventory new record with sa_no SA091C020 created from Select Artifacts
+LithicInventory new record with sa_no SA091C021 created from Select Artifacts
+CeramicVessel new record with sa_no SA091C023 created from Select Artifacts
+LithicInventory new record with sa_no SA091C024 created from Select Artifacts
+BoneInventory new record with sa_no SA091W100 created from Select Artifacts
+LithicInventory new record with sa_no SA091W010 created from Select Artifacts
+LithicInventory new record with sa_no SA092A031 created from Select Artifacts
+LithicInventory new record with sa_no SA092A032 created from Select Artifacts
+LithicInventory new record with sa_no SA093W020 created from Select Artifacts
+LithicInventory new record with sa_no SA093W032 created from Select Artifacts
+LithicInventory new record with sa_no SA093W033 created from Select Artifacts
+LithicInventory new record with sa_no SA093W034 created from Select Artifacts
+LithicInventory new record with sa_no SA093W035 created from Select Artifacts
+LithicInventory new record with sa_no SA093W036 created from Select Artifacts
+LithicInventory new record with sa_no SA093W037 created from Select Artifacts
+LithicInventory new record with sa_no SA093W038 created from Select Artifacts
+LithicInventory new record with sa_no SA093W039 created from Select Artifacts
+LithicInventory new record with sa_no SA093W043 created from Select Artifacts
+CeramicVessel new record with sa_no SA094C002 created from Select Artifacts
+CeramicVessel new record with sa_no SA094C003 created from Select Artifacts
+LithicInventory new record with sa_no SA094C004 created from Select Artifacts
+CeramicVessel new record with sa_no SA094C005 created from Select Artifacts
+LithicInventory new record with sa_no SA094C006 created from Select Artifacts
+Perishable new record with sa_no SA094C007 created from Select Artifacts
+BoneInventory new record with sa_no SA094W003 created from Select Artifacts
+CeramicVessel new record with sa_no SA094W006 created from Select Artifacts
+LithicInventory new record with sa_no SA094W009 created from Select Artifacts
+Ornament new record with sa_no SA094W010 created from Select Artifacts
+Ornament new record with sa_no SA094W011 created from Select Artifacts
+BoneInventory new record with sa_no SA094W012 created from Select Artifacts
+LithicInventory new record with sa_no SA094W013 created from Select Artifacts
+LithicInventory new record with sa_no SA094W014 created from Select Artifacts
+LithicInventory new record with sa_no SA094W015 created from Select Artifacts
+LithicInventory new record with sa_no SA094W016 created from Select Artifacts
+Ornament new record with sa_no SA094W017 created from Select Artifacts
+BoneInventory new record with sa_no SA094W018 created from Select Artifacts
+Ornament new record with sa_no SA094W019 created from Select Artifacts
+LithicInventory new record with sa_no SA094W020 created from Select Artifacts
+BoneInventory new record with sa_no SA094W021 created from Select Artifacts
+BoneInventory new record with sa_no SA094W022 created from Select Artifacts
+Ornament new record with sa_no SA094W023 created from Select Artifacts
+LithicInventory new record with sa_no SA094W024 created from Select Artifacts
+LithicInventory new record with sa_no SA094W025 created from Select Artifacts
+LithicInventory new record with sa_no SA094W026 created from Select Artifacts
+LithicInventory new record with sa_no SA094W027 created from Select Artifacts
+LithicInventory new record with sa_no SA094W028 created from Select Artifacts
+LithicInventory new record with sa_no SA094W030 created from Select Artifacts
+LithicInventory new record with sa_no SA094W031 created from Select Artifacts
+LithicInventory new record with sa_no SA094W032 created from Select Artifacts
+LithicInventory new record with sa_no SA094W033 created from Select Artifacts
+LithicInventory new record with sa_no SA094W034 created from Select Artifacts
+LithicInventory new record with sa_no SA094W035 created from Select Artifacts
+LithicInventory new record with sa_no SA094W036 created from Select Artifacts
+LithicInventory new record with sa_no SA096W001 created from Select Artifacts
+LithicInventory new record with sa_no SA096W009 created from Select Artifacts
+LithicInventory new record with sa_no SA096W010 created from Select Artifacts
+BoneInventory new record with sa_no SA096W011 created from Select Artifacts
+LithicInventory new record with sa_no SA097A1003 created from Select Artifacts
+CeramicVessel new record with sa_no SA097B001 created from Select Artifacts
+CeramicVessel new record with sa_no SA097B003 created from Select Artifacts
+LithicInventory new record with sa_no SA097W1008 created from Select Artifacts
+LithicInventory new record with sa_no SA097W2001.1 created from Select Artifacts
+BoneInventory new record with sa_no SA097W2001.2 created from Select Artifacts
+WoodInventory new record with sa_no SA097W2016 created from Select Artifacts
+CeramicInventory new record with sa_no SA097W2017 created from Select Artifacts
+CeramicInventory new record with sa_no SA097W2018 created from Select Artifacts
+feature 097W:L-3-8:2001.0 created from Select Artifacts
+LithicInventory new record with sa_no SA097W2019 created from Select Artifacts
+feature 097W:H-1-5:2001.0 created from Select Artifacts
+LithicInventory new record with sa_no SA097W4001 created from Select Artifacts
+LithicInventory new record with sa_no SA097W4005 created from Select Artifacts
+LithicInventory new record with sa_no SA097W4006 created from Select Artifacts
+LithicInventory new record with sa_no SA097W4007 created from Select Artifacts
+LithicInventory new record with sa_no SA097W4009 created from Select Artifacts
+LithicInventory new record with sa_no SA097W4010 created from Select Artifacts
+feature 097W:D-2-16:2014.0 created from Select Artifacts
+CeramicVessel new record with sa_no SA097W4011 created from Select Artifacts
+feature 097W:D-2-16:2015.0 created from Select Artifacts
+LithicInventory new record with sa_no SA097W4012 created from Select Artifacts
+feature 097W:D-2-16:2016.0 created from Select Artifacts
+LithicInventory new record with sa_no SA097W4013 created from Select Artifacts
+feature 097W:D-2-16:2017.0 created from Select Artifacts
+LithicInventory new record with sa_no SA097W4014 created from Select Artifacts
+feature 097W:D-2-16:2018.0 created from Select Artifacts
+LithicInventory new record with sa_no SA097W4015 created from Select Artifacts
+feature 097W:D-2-16:2019.0 created from Select Artifacts
+LithicInventory new record with sa_no SA097W4016 created from Select Artifacts
+feature 097W:D-2-16:2020.0 created from Select Artifacts
+LithicInventory new record with sa_no SA097W4017 created from Select Artifacts
+feature 097W:D-2-16:2021.0 created from Select Artifacts
+LithicInventory new record with sa_no SA097W4018 created from Select Artifacts
+feature 097W:D-2-16:2022.0 created from Select Artifacts
+LithicInventory new record with sa_no SA097W4019 created from Select Artifacts
+LithicInventory new record with sa_no SA097W4035 created from Select Artifacts
+LithicInventory new record with sa_no SA097W4036 created from Select Artifacts
+LithicInventory new record with sa_no SA100W001 created from Select Artifacts
+CeramicVessel new record with sa_no SA100W002 created from Select Artifacts
+CeramicVessel new record with sa_no SA100W304 created from Select Artifacts
+CeramicVessel new record with sa_no SA100W305 created from Select Artifacts
+CeramicVessel new record with sa_no SA100W306 created from Select Artifacts
+CeramicVessel new record with sa_no SA100W307 created from Select Artifacts
+CeramicVessel new record with sa_no SA100W311 created from Select Artifacts
+WoodInventory new record with sa_no SA100W312 created from Select Artifacts
+LithicInventory new record with sa_no SA100W4002 created from Select Artifacts
+BoneInventory new record with sa_no SA100W4003 created from Select Artifacts
+BoneInventory new record with sa_no SA100W4004 created from Select Artifacts
+BoneInventory new record with sa_no SA100W4005 created from Select Artifacts
+CeramicVessel new record with sa_no SA100W5024 created from Select Artifacts
+LithicInventory new record with sa_no SA101W001 created from Select Artifacts
+CeramicVessel new record with sa_no SA102A4015 created from Select Artifacts
+LithicInventory new record with sa_no SA102A4016 created from Select Artifacts
+LithicInventory new record with sa_no SA102A5005 created from Select Artifacts
+LithicInventory new record with sa_no SA102A5007 created from Select Artifacts
+CeramicVessel new record with sa_no SA102B001 created from Select Artifacts
+CeramicVessel new record with sa_no SA102B003 created from Select Artifacts
+CeramicVessel new record with sa_no SA102B005 created from Select Artifacts
+LithicInventory new record with sa_no SA102B006 created from Select Artifacts
+Perishable new record with sa_no SA102B008 created from Select Artifacts
+BoneInventory new record with sa_no SA102B010 created from Select Artifacts
+CeramicVessel new record with sa_no SA102B011 created from Select Artifacts
+LithicInventory new record with sa_no SA102D5001 created from Select Artifacts
+LithicInventory new record with sa_no SA102D5002 created from Select Artifacts
+LithicInventory new record with sa_no SA102D5003 created from Select Artifacts
+LithicInventory new record with sa_no SA102D5004 created from Select Artifacts
+LithicInventory new record with sa_no SA118W014 created from Select Artifacts
+CeramicVessel new record with sa_no SA118W015 created from Select Artifacts
+LithicInventory new record with sa_no SA118W049 created from Select Artifacts
+LithicInventory new record with sa_no SA118W050 created from Select Artifacts
+LithicInventory new record with sa_no SA118W051 created from Select Artifacts
+CeramicVessel new record with sa_no SA118W052 created from Select Artifacts
+LithicInventory new record with sa_no SA118W053 created from Select Artifacts
+LithicInventory new record with sa_no SA118W054 created from Select Artifacts
+LithicInventory new record with sa_no SA118W055 created from Select Artifacts
+CeramicVessel new record with sa_no SA118W056 created from Select Artifacts
+LithicInventory new record with sa_no SA118W057 created from Select Artifacts
+LithicInventory new record with sa_no SA118W058 created from Select Artifacts
+BoneInventory new record with sa_no SA118W060 created from Select Artifacts
+LithicInventory new record with sa_no SA118W064 created from Select Artifacts
+LithicInventory new record with sa_no SA118W065 created from Select Artifacts
+LithicInventory new record with sa_no SA118W067 created from Select Artifacts
+LithicInventory new record with sa_no SA118W068 created from Select Artifacts
+LithicInventory new record with sa_no SA118W069 created from Select Artifacts
+LithicInventory new record with sa_no SA118W070 created from Select Artifacts
+LithicInventory new record with sa_no SA118W071 created from Select Artifacts
+LithicInventory new record with sa_no SA118W073 created from Select Artifacts
+CeramicInventory new record with sa_no SA118W074 created from Select Artifacts
+LithicInventory new record with sa_no SA118W075 created from Select Artifacts
+LithicInventory new record with sa_no SA119W001 created from Select Artifacts
+feature 119W:L-2.3-11.3:17.0 created from Select Artifacts
+LithicInventory new record with sa_no SA119W014 created from Select Artifacts
+LithicInventory new record with sa_no SA119W015 created from Select Artifacts
+LithicInventory new record with sa_no SA119W020 created from Select Artifacts
+LithicInventory new record with sa_no SA119W021 created from Select Artifacts
+LithicInventory new record with sa_no SA119W023 created from Select Artifacts
+LithicInventory new record with sa_no SA119W041.1 created from Select Artifacts
+WoodInventory new record with sa_no SA119W042.1 created from Select Artifacts
+LithicInventory new record with sa_no SA119W044.1 created from Select Artifacts
+feature 119W:H-6.6-14.6:26.0 created from Select Artifacts
+LithicInventory new record with sa_no SA119W047 created from Select Artifacts
+LithicInventory new record with sa_no SA119W048 created from Select Artifacts
+WoodInventory new record with sa_no SA119W049 created from Select Artifacts
+CeramicVessel new record with sa_no SA119W051 created from Select Artifacts
+LithicInventory new record with sa_no SA119W052 created from Select Artifacts
+LithicInventory new record with sa_no SA119W053 created from Select Artifacts
+LithicInventory new record with sa_no SA119W055 created from Select Artifacts
+WoodInventory new record with sa_no SA119W057 created from Select Artifacts
+CeramicVessel new record with sa_no SA119W060 created from Select Artifacts
+Perishable new record with sa_no SA119W061 created from Select Artifacts
+feature 119W:no data:80.0 created from Select Artifacts
+LithicInventory new record with sa_no SA119W062 created from Select Artifacts
+LithicInventory new record with sa_no SA119W063 created from Select Artifacts
+LithicInventory new record with sa_no SA119W064 created from Select Artifacts
+LithicInventory new record with sa_no SA119W065 created from Select Artifacts
+LithicInventory new record with sa_no SA119W066 created from Select Artifacts
+LithicInventory new record with sa_no SA119W067 created from Select Artifacts
+LithicInventory new record with sa_no SA119W068 created from Select Artifacts
+LithicInventory new record with sa_no SA119W070 created from Select Artifacts
+CeramicVessel new record with sa_no SA119W071 created from Select Artifacts
+LithicInventory new record with sa_no SA119W072 created from Select Artifacts
+LithicInventory new record with sa_no SA119W085 created from Select Artifacts
+LithicInventory new record with sa_no SA119W086 created from Select Artifacts
+LithicInventory new record with sa_no SA119W087 created from Select Artifacts
+LithicInventory new record with sa_no SA119W088 created from Select Artifacts
+LithicInventory new record with sa_no SA119W091 created from Select Artifacts
+LithicInventory new record with sa_no SA119W092 created from Select Artifacts
+LithicInventory new record with sa_no SA119W094 created from Select Artifacts
+LithicInventory new record with sa_no SA119W095 created from Select Artifacts
+stratum 119W:H-4.5-22.5 created from Select Artifacts
+feature 119W:H-4.5-22.5:74.0 created from Select Artifacts
+LithicInventory new record with sa_no SA119W098 created from Select Artifacts
+LithicInventory new record with sa_no SA119W102 created from Select Artifacts
+stratum 119W:W-1-91 created from Select Artifacts
+feature 119W:W-1-91:45.0 created from Select Artifacts
+WoodInventory new record with sa_no SA119W103 created from Select Artifacts
+LithicInventory new record with sa_no SA119W106 created from Select Artifacts
+feature 119W:I-11-39:104.0 created from Select Artifacts
+LithicInventory new record with sa_no SA119W111 created from Select Artifacts
+LithicInventory new record with sa_no SA119W117 created from Select Artifacts
+LithicInventory new record with sa_no SA119W118 created from Select Artifacts
+LithicInventory new record with sa_no SA119W119 created from Select Artifacts
+CeramicVessel new record with sa_no SA119W120 created from Select Artifacts
+Perishable new record with sa_no SA119W121 created from Select Artifacts
+feature 119W:M-1-30:35.0 created from Select Artifacts
+LithicInventory new record with sa_no SA119W122 created from Select Artifacts
+LithicInventory new record with sa_no SA119W123 created from Select Artifacts
+LithicInventory new record with sa_no SA119W124 created from Select Artifacts
+LithicInventory new record with sa_no SA119W125 created from Select Artifacts
+LithicInventory new record with sa_no SA119W126 created from Select Artifacts
+LithicInventory new record with sa_no SA119W127 created from Select Artifacts
+LithicInventory new record with sa_no SA119W128 created from Select Artifacts
+LithicInventory new record with sa_no SA119W129 created from Select Artifacts
+LithicInventory new record with sa_no SA119W130 created from Select Artifacts
+LithicInventory new record with sa_no SA119W131 created from Select Artifacts
+LithicInventory new record with sa_no SA119W132 created from Select Artifacts
+LithicInventory new record with sa_no SA119W133 created from Select Artifacts
+LithicInventory new record with sa_no SA121A043 created from Select Artifacts
+stratum 121W:H-1-6 created from Select Artifacts
+feature 121W:H-1-6:1.0 created from Select Artifacts
+LithicInventory new record with sa_no SA121W002 created from Select Artifacts
+CeramicVessel new record with sa_no SA121W034 created from Select Artifacts
+CeramicVessel new record with sa_no SA121W035 created from Select Artifacts
+CeramicVessel new record with sa_no SA121W036 created from Select Artifacts
+CeramicVessel new record with sa_no SA121W037 created from Select Artifacts
+CeramicVessel new record with sa_no SA121W038 created from Select Artifacts
+Ornament new record with sa_no SA121W040 created from Select Artifacts
+CeramicVessel new record with sa_no SA121W041 created from Select Artifacts
+Perishable new record with sa_no SA121W042 created from Select Artifacts
+LithicInventory new record with sa_no SA121Z002 created from Select Artifacts
+feature 121Z:H-1-6:3.0 created from Select Artifacts
+Perishable new record with sa_no SA121Z004 created from Select Artifacts
+LithicInventory new record with sa_no SA121Z005 created from Select Artifacts
+LithicInventory new record with sa_no SA121Z008 created from Select Artifacts
+CeramicVessel new record with sa_no SA122W001 created from Select Artifacts
+CeramicVessel new record with sa_no SA122W002 created from Select Artifacts
+CeramicVessel new record with sa_no SA122W003 created from Select Artifacts
+CeramicVessel new record with sa_no SA122W004 created from Select Artifacts
+LithicInventory new record with sa_no SA122W005 created from Select Artifacts
+CeramicVessel new record with sa_no SA123B007 created from Select Artifacts
+CeramicInventory new record with sa_no SA124B042 created from Select Artifacts
+CeramicVessel new record with sa_no SA124Z041 created from Select Artifacts
+LithicInventory new record with sa_no SA127A004 created from Select Artifacts
+LithicInventory new record with sa_no SA127A005 created from Select Artifacts
+LithicInventory new record with sa_no SA127A006 created from Select Artifacts
+feature 127A:L-1-7:8.0 created from Select Artifacts
+LithicInventory new record with sa_no SA127A011 created from Select Artifacts
+CeramicVessel new record with sa_no SA127B002 created from Select Artifacts
+WoodInventory new record with sa_no SA127B004 created from Select Artifacts
+LithicInventory new record with sa_no SA127W054 created from Select Artifacts
+LithicInventory new record with sa_no SA127W057 created from Select Artifacts
+WoodInventory new record with sa_no SA127W058 created from Select Artifacts
+WoodInventory new record with sa_no SA127W059 created from Select Artifacts
+CeramicVessel new record with sa_no SA127W060 created from Select Artifacts
+LithicInventory new record with sa_no SA127W061 created from Select Artifacts
+LithicInventory new record with sa_no SA127W063 created from Select Artifacts
+LithicInventory new record with sa_no SA127W064 created from Select Artifacts
+LithicInventory new record with sa_no SA127W065 created from Select Artifacts
+LithicInventory new record with sa_no SA127W067 created from Select Artifacts
+LithicInventory new record with sa_no SA127W068 created from Select Artifacts
+LithicInventory new record with sa_no SA127W070 created from Select Artifacts
+LithicInventory new record with sa_no SA127W071 created from Select Artifacts
+LithicInventory new record with sa_no SA127W072 created from Select Artifacts
+LithicInventory new record with sa_no SA127W073 created from Select Artifacts
+LithicInventory new record with sa_no SA127W074 created from Select Artifacts
+LithicInventory new record with sa_no SA127W075 created from Select Artifacts
+LithicInventory new record with sa_no SA127W076 created from Select Artifacts
+LithicInventory new record with sa_no SA127W078 created from Select Artifacts
+LithicInventory new record with sa_no SA127W079 created from Select Artifacts
+LithicInventory new record with sa_no SA127W080 created from Select Artifacts
+LithicInventory new record with sa_no SA127W081 created from Select Artifacts
+LithicInventory new record with sa_no SA127W082 created from Select Artifacts
+LithicInventory new record with sa_no SA127W083 created from Select Artifacts
+LithicInventory new record with sa_no SA127W084 created from Select Artifacts
+LithicInventory new record with sa_no SA127W085 created from Select Artifacts
+LithicInventory new record with sa_no SA127W086 created from Select Artifacts
+LithicInventory new record with sa_no SA127W088 created from Select Artifacts
+LithicInventory new record with sa_no SA127W092 created from Select Artifacts
+LithicInventory new record with sa_no SA127W094 created from Select Artifacts
+LithicInventory new record with sa_no SA127W098 created from Select Artifacts
+CeramicVessel new record with sa_no SA127W101 created from Select Artifacts
+CeramicVessel new record with sa_no SA127W102 created from Select Artifacts
+CeramicVessel new record with sa_no SA127W108 created from Select Artifacts
+LithicInventory new record with sa_no SA127W110 created from Select Artifacts
+Perishable new record with sa_no SA127W112 created from Select Artifacts
+WoodInventory new record with sa_no SA127W113 created from Select Artifacts
+CeramicVessel new record with sa_no SA127W117 created from Select Artifacts
+CeramicVessel new record with sa_no SA127W118 created from Select Artifacts
+CeramicVessel new record with sa_no SA127W119 created from Select Artifacts
+CeramicVessel new record with sa_no SA127W129 created from Select Artifacts
+LithicInventory new record with sa_no SA127W131 created from Select Artifacts
+CeramicVessel new record with sa_no SA127W133 created from Select Artifacts
+CeramicVessel new record with sa_no SA127W134 created from Select Artifacts
+CeramicVessel new record with sa_no SA127W135 created from Select Artifacts
+CeramicVessel new record with sa_no SA127W136 created from Select Artifacts
+CeramicVessel new record with sa_no SA127W139 created from Select Artifacts
+CeramicVessel new record with sa_no SA127W143 created from Select Artifacts
+LithicInventory new record with sa_no SA127W146 created from Select Artifacts
+LithicInventory new record with sa_no SA127W149 created from Select Artifacts
+LithicInventory new record with sa_no SA127W151 created from Select Artifacts
+LithicInventory new record with sa_no SA127W152 created from Select Artifacts
+Perishable new record with sa_no SA127W153 created from Select Artifacts
+Perishable new record with sa_no SA127W156 created from Select Artifacts
+Ornament new record with sa_no SA127W158 created from Select Artifacts
+LithicInventory new record with sa_no SA128W001 created from Select Artifacts
+LithicInventory new record with sa_no SA128W002 created from Select Artifacts
+Perishable new record with sa_no SA129W001 created from Select Artifacts
+CeramicVessel new record with sa_no SA129W004 created from Select Artifacts
+LithicInventory new record with sa_no SA129W032 created from Select Artifacts
+LithicInventory new record with sa_no SA129W033 created from Select Artifacts
+LithicInventory new record with sa_no SA129W034 created from Select Artifacts
+feature 129W:W-1-91:45.0 created from Select Artifacts
+WoodInventory new record with sa_no SA129W103 created from Select Artifacts
+WoodInventory new record with sa_no SA129W104 created from Select Artifacts
+LithicInventory new record with sa_no SA129W105 created from Select Artifacts
+LithicInventory new record with sa_no SA129W109 created from Select Artifacts
+LithicInventory new record with sa_no SA129W111 created from Select Artifacts
+LithicInventory new record with sa_no SA129W113 created from Select Artifacts
+LithicInventory new record with sa_no SA129W114 created from Select Artifacts
+LithicInventory new record with sa_no SA129W115 created from Select Artifacts
+CeramicVessel new record with sa_no SA129W125 created from Select Artifacts
+CeramicVessel new record with sa_no SA129W129 created from Select Artifacts
+CeramicVessel new record with sa_no SA129W130 created from Select Artifacts
+LithicInventory new record with sa_no SA129W132 created from Select Artifacts
+Perishable new record with sa_no SA129W133 created from Select Artifacts
+CeramicVessel new record with sa_no SA129W134 created from Select Artifacts
+CeramicVessel new record with sa_no SA129W135 created from Select Artifacts
+Ornament new record with sa_no SA129W138 created from Select Artifacts
+LithicInventory new record with sa_no SA129W149 created from Select Artifacts
+LithicInventory new record with sa_no SA129W154 created from Select Artifacts
+LithicInventory new record with sa_no SA129W156 created from Select Artifacts
+LithicInventory new record with sa_no SA129W157 created from Select Artifacts
+LithicInventory new record with sa_no SA129W158 created from Select Artifacts
+LithicInventory new record with sa_no SA129W159 created from Select Artifacts
+LithicInventory new record with sa_no SA129W160 created from Select Artifacts
+LithicInventory new record with sa_no SA129W162 created from Select Artifacts
+LithicInventory new record with sa_no SA129W164 created from Select Artifacts
+LithicInventory new record with sa_no SA129W165 created from Select Artifacts
+LithicInventory new record with sa_no SA129W166 created from Select Artifacts
+LithicInventory new record with sa_no SA129W167 created from Select Artifacts
+LithicInventory new record with sa_no SA129W168 created from Select Artifacts
+LithicInventory new record with sa_no SA129W169 created from Select Artifacts
+LithicInventory new record with sa_no SA129W170 created from Select Artifacts
+CeramicVessel new record with sa_no SA129W171 created from Select Artifacts
+LithicInventory new record with sa_no SA129W179 created from Select Artifacts
+LithicInventory new record with sa_no SA129W183 created from Select Artifacts
+LithicInventory new record with sa_no SA130W029 created from Select Artifacts
+LithicInventory new record with sa_no SA130W030 created from Select Artifacts
+LithicInventory new record with sa_no SA130W031 created from Select Artifacts
+LithicInventory new record with sa_no SA130W032 created from Select Artifacts
+LithicInventory new record with sa_no SA130W033 created from Select Artifacts
+LithicInventory new record with sa_no SA130W034 created from Select Artifacts
+LithicInventory new record with sa_no SA130W035 created from Select Artifacts
+LithicInventory new record with sa_no SA130W044 created from Select Artifacts
+LithicInventory new record with sa_no SA130W048 created from Select Artifacts
+Ornament new record with sa_no SA130W051 created from Select Artifacts
+Ornament new record with sa_no SA130W052 created from Select Artifacts
+Ornament new record with sa_no SA130W053 created from Select Artifacts
+LithicInventory new record with sa_no SA130W054 created from Select Artifacts
+LithicInventory new record with sa_no SA130W055 created from Select Artifacts
+LithicInventory new record with sa_no SA130W056 created from Select Artifacts
+LithicInventory new record with sa_no SA130W057 created from Select Artifacts
+LithicInventory new record with sa_no SA130W058 created from Select Artifacts
+Ornament new record with sa_no SA130W059 created from Select Artifacts
+Ornament new record with sa_no SA130W063 created from Select Artifacts
+feature 130W:L-2.3-11.3:3.0 created from Select Artifacts
+Ornament new record with sa_no SA130W066 created from Select Artifacts
+Ornament new record with sa_no SA130W067 created from Select Artifacts
+LithicInventory new record with sa_no SA130W068 created from Select Artifacts
+LithicInventory new record with sa_no SA130W069 created from Select Artifacts
+LithicInventory new record with sa_no SA130W070 created from Select Artifacts
+LithicInventory new record with sa_no SA130W071 created from Select Artifacts
+LithicInventory new record with sa_no SA130W072 created from Select Artifacts
+LithicInventory new record with sa_no SA130W074 created from Select Artifacts
+LithicInventory new record with sa_no SA130W075 created from Select Artifacts
+LithicInventory new record with sa_no SA130W076 created from Select Artifacts
+Ornament new record with sa_no SA130W077 created from Select Artifacts
+Ornament new record with sa_no SA130W078 created from Select Artifacts
+Ornament new record with sa_no SA130W080 created from Select Artifacts
+Ornament new record with sa_no SA130W081 created from Select Artifacts
+Ornament new record with sa_no SA130W082 created from Select Artifacts
+Ornament new record with sa_no SA130W083 created from Select Artifacts
+Ornament new record with sa_no SA130W084 created from Select Artifacts
+LithicInventory new record with sa_no SA136W001 created from Select Artifacts
+LithicInventory new record with sa_no SA136W002 created from Select Artifacts
+LithicInventory new record with sa_no SA136W003 created from Select Artifacts
+LithicInventory new record with sa_no SA136W004 created from Select Artifacts
+feature 136W:D-1-9:2.0 created from Select Artifacts
+LithicInventory new record with sa_no SA136W005 created from Select Artifacts
+LithicInventory new record with sa_no SA136W006 created from Select Artifacts
+LithicInventory new record with sa_no SA136W007 created from Select Artifacts
+LithicInventory new record with sa_no SA136W008 created from Select Artifacts
+LithicInventory new record with sa_no SA136W009 created from Select Artifacts
+LithicInventory new record with sa_no SA136W010 created from Select Artifacts
+LithicInventory new record with sa_no SA136W011 created from Select Artifacts
+LithicInventory new record with sa_no SA136W029 created from Select Artifacts
+CeramicVessel new record with sa_no SA138Z003 created from Select Artifacts
+CeramicVessel new record with sa_no SA138Z004 created from Select Artifacts
+CeramicVessel new record with sa_no SA138Z005 created from Select Artifacts
+CeramicVessel new record with sa_no SA143W002 created from Select Artifacts
+CeramicVessel new record with sa_no SA143W003 created from Select Artifacts
+CeramicVessel new record with sa_no SA143W004 created from Select Artifacts
+CeramicVessel new record with sa_no SA143W005 created from Select Artifacts
+CeramicVessel new record with sa_no SA149W002 created from Select Artifacts
 stratum 020P:B-1-2.5 created from Soils
 stratum 020P:B-4.4-4.7 created from Soils
 feature 020P:L-10-13:16.0 created from Soils


### PR DESCRIPTION
if no matching row found in inventory / analysis table
creates new record with minimal information
if matching row found then adds some information to it
had to rename / create several columns across tables
associates SA with features instead of strata

unable to locate any open issues about the SA table being split up, or else this would close them!