### PR TITLE
Fix image tests after displayability updates

### DIFF
--- a/test/fixtures/images.yml
+++ b/test/fixtures/images.yml
@@ -17,3 +17,4 @@ one:
   storage_location: MyString
   entered_by: MyString
   notes: MyString
+  file_exists: true

--- a/test/models/image_test.rb
+++ b/test/models/image_test.rb
@@ -41,16 +41,6 @@ class ImageTest < ActiveSupport::TestCase
 
     # first ImageHumanRemain should be true
     assert @item.displayable?
-
-    # Set image comments to include "burial", not displayable
-    @item.comments = "Burial"
-    assert_not @item.displayable?
-    # Reset comments to a displayable value
-    @item.comments = "MyString"
-
-    # Add an ImageSubject of "Feature-burial", not displayable
-    @item.image_subjects << ImageSubject.create(name: "Feature-burial")
-    assert_not @item.displayable?
   end
 
 end


### PR DESCRIPTION
Adds file_exists: true to fixture for first image
Removes tests for logic removed to exclude comments and features