### PR TITLE
Fix CSS reorg mixup with navbar styling

### DIFF
--- a/app/assets/stylesheets/style.scss.erb
+++ b/app/assets/stylesheets/style.scss.erb
@@ -319,10 +319,8 @@ a.content {
 
 // Navbar
 
-.sparc_navbar {
+.navbar-default {
   background-color: $brand-primary;
-  background: url(<%= asset_path 'topographic_bottom.jpg' %>) center top no-repeat $brand-primary;
-  margin-top: -4px;
   a {
     font-size: 1.1em;
   }
@@ -337,7 +335,12 @@ a.content {
   }
 }
 
-// logo (words) 
+.sparc_navbar {
+  background: url(<%= asset_path 'topographic_bottom.jpg' %>) center top no-repeat $brand-primary;
+  margin-top: -4px;
+}
+
+// logo (words)
 
 .header_words {
   display: inline-block;


### PR DESCRIPTION
.sparc_navbar properties were merged with .navbar_default's but then
navbar_default was removed

Split .sparc_navbar back out and restored .navbar_default

Search https://github.com/CDRH/sparc/pull/363/files for `navbar_default` and one can see the mixup